### PR TITLE
Create requirements-arch.txt

### DIFF
--- a/tools/requirements-arch.txt
+++ b/tools/requirements-arch.txt
@@ -1,0 +1,14 @@
+binutils
+curl
+git
+make
+7zip
+python-pip
+python-virtualenv
+unzip
+wget
+7zip
+openssl
+lib32-glibc
+zsh
+clang


### PR DESCRIPTION
Added dependency list for Arch/Artix. Hopefully this makes building on Arch-based distros easier.